### PR TITLE
Fixed limitation when using AspNetAutoInstrumentationModule

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,3 +34,4 @@ jobs:
           
         - name: Run tests
           run: dotnet test src/test/bin/Release/${{matrix.version}}/AWSXRayRecorder.AutoInstrumentation.UnitTests.dll
+          

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,36 @@
+name: X-Ray .NET Agent PR build workflow 
+
+on:
+    pull_request:
+        branches:
+            - master
+            
+jobs:
+    build:
+        name: build
+        runs-on: ${{ matrix.os }}
+        
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [windows-latest,ubuntu-latest]
+                version: [net452,netcoreapp2.0]
+                exclude:
+                  - os: ubuntu-latest
+                    version: net452
+                
+        steps:
+        - name: Checkout repository
+        - uses: actions/checkout@v2
+          
+        - name: Clean solution
+          run: dotnet clean src/AWSXRayRecorder.AutoInstrumentation.sln --configuration Release && dotnet nuget locals all --clear
+        
+        - name: Install dependencies
+          run: dotnet restore src/AWSXRayRecorder.AutoInstrumentation.sln --locked-mode
+          
+        - name: Build solution
+          run: dotnet build src/AWSXRayRecorder.AutoInstrumentation.sln --configuration Release --no-restore
+          
+        - name: Run tests
+          run: dotnet test src/test/bin/Release/${{matrix.version}}/AWSXRayRecorder.AutoInstrumentation.UnitTests.dll

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -21,7 +21,7 @@ jobs:
                 
         steps:
         - name: Checkout repository
-        - uses: actions/checkout@v2
+          uses: actions/checkout@v2
           
         - name: Clean solution
           run: dotnet clean src/AWSXRayRecorder.AutoInstrumentation.sln --configuration Release && dotnet nuget locals all --clear

--- a/src/test/AWSXRayRecorder.AutoInstrumentation.Unittests.csproj
+++ b/src/test/AWSXRayRecorder.AutoInstrumentation.Unittests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -10,6 +10,10 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\buildtools\local-development.snk</AssemblyOriginatorKeyFile>
     <RootNamespace>Amazon.XRay.Recorder.AutoInstrumentation.Unittests</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
+    <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*

Issue: https://github.com/aws/aws-xray-dotnet-agent/issues/18, https://github.com/aws/aws-xray-dotnet-agent/issues/22

*Description of changes:*
Removing loading the dlls since we require user to import the tracing library in beta stage and all required dlls will be shipped together with user's application.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
