### PR TITLE
Bumped AWSXRayRecorder.Handler.AwsSdk version

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,25 +1,25 @@
 name: X-Ray .NET Agent PR build workflow 
 
 on:
-    pull_request:
-        branches:
-            - master
+  pull_request:
+    branches:
+      - master
             
 jobs:
-    build:
-        name: build
-        runs-on: ${{ matrix.os }}
+  build:
+    name: build
+    runs-on: ${{ matrix.os }}
         
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [windows-latest,ubuntu-latest]
-                version: [net452,netcoreapp2.0]
-                exclude:
-                  - os: ubuntu-latest
-                    version: net452
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest,ubuntu-latest]
+        version: [net452,netcoreapp2.0]
+        exclude:
+          - os: ubuntu-latest
+            version: net452
                 
-        steps:
+      steps:
         - name: Checkout repository
           uses: actions/checkout@v2
           
@@ -34,4 +34,3 @@ jobs:
           
         - name: Run tests
           run: dotnet test src/test/bin/Release/${{matrix.version}}/AWSXRayRecorder.AutoInstrumentation.UnitTests.dll
-          

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -8,16 +8,12 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
         
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest,ubuntu-latest]
         version: [net452,netcoreapp2.0]
-        exclude:
-          - os: ubuntu-latest
-            version: net452
                 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,18 +19,18 @@ jobs:
           - os: ubuntu-latest
             version: net452
                 
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
           
-        - name: Clean solution
-          run: dotnet clean src/AWSXRayRecorder.AutoInstrumentation.sln --configuration Release && dotnet nuget locals all --clear
+      - name: Clean solution
+        run: dotnet clean src/AWSXRayRecorder.AutoInstrumentation.sln --configuration Release && dotnet nuget locals all --clear
         
-        - name: Install dependencies
-          run: dotnet restore src/AWSXRayRecorder.AutoInstrumentation.sln --locked-mode
+      - name: Install dependencies
+        run: dotnet restore src/AWSXRayRecorder.AutoInstrumentation.sln --locked-mode
           
-        - name: Build solution
-          run: dotnet build src/AWSXRayRecorder.AutoInstrumentation.sln --configuration Release --no-restore
+      - name: Build solution
+        run: dotnet build src/AWSXRayRecorder.AutoInstrumentation.sln --configuration Release --no-restore
           
-        - name: Run tests
-          run: dotnet test src/test/bin/Release/${{matrix.version}}/AWSXRayRecorder.AutoInstrumentation.UnitTests.dll
+      - name: Run tests
+        run: dotnet test src/test/bin/Release/${{matrix.version}}/AWSXRayRecorder.AutoInstrumentation.UnitTests.dll

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,7 +3,7 @@ name: X-Ray .NET Agent PR build workflow
 on:
   pull_request:
     branches:
-      - master
+      - main
             
 jobs:
   build:

--- a/src/sdk/AWSXRayRecorder.AutoInstrumentation.csproj
+++ b/src/sdk/AWSXRayRecorder.AutoInstrumentation.csproj
@@ -30,8 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSXRayRecorder.Core" Version="2.9.0" />
-    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.1" />
+    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/test/AWSXRayRecorder.AutoInstrumentation.Unittests.csproj
+++ b/src/test/AWSXRayRecorder.AutoInstrumentation.Unittests.csproj
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSXRayRecorder.Core" Version="2.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Bumped `AWSXRayRecorder.Handler.AwsSdk` to 2.8.3
- Removed dependency on `AWSXRayRecorder.Core`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
