### PR TITLE
fix(daily-scan): preserve trivyignore file across release tag checkout

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -90,9 +90,12 @@ jobs:
       - name: Build .NET solution at release tag for scanning
         if: always()
         run: |
+          cp .github/trivy/daily-scan.trivyignore.yaml /tmp/daily-scan.trivyignore.yaml
           latest_tag=$(git tag -l 'v*' | sort -rV | head -1)
           echo "Building at release tag: $latest_tag"
           git checkout "$latest_tag"
+          mkdir -p .github/trivy
+          cp /tmp/daily-scan.trivyignore.yaml .github/trivy/daily-scan.trivyignore.yaml
           dotnet build src/AWSXRayRecorder.AutoInstrumentation.sln --configuration Release
 
       - name: Perform high severity scan on built artifacts


### PR DESCRIPTION
## Problem
Both Trivy scan steps fail with:
```
FATAL: ignore file not found: .github/trivy/daily-scan.trivyignore.yaml
```

The workflow checks out the latest release tag (`git checkout "$latest_tag"`) to build artifacts for Trivy scanning. This replaces the entire working tree with the tag's content, and since the trivyignore file was added to `main` after the last release, it doesn't exist at the tag.

## Fix
Save the trivyignore file to `/tmp` before the tag checkout and restore it afterward.

## Impact
Trivy scans will actually run instead of fatally erroring. Currently both high and low severity Trivy scans are completely broken in this repo.

## Validation
Verified from run [23353727654](https://github.com/aws/aws-xray-dotnet-agent/actions/runs/23353727654) — both Trivy steps exit code 1 with the FATAL error.