### PR TITLE
fix(daily-scan): suppress System.Interactive.Async false positive

### DIFF
--- a/.github/dependency-check-suppressions.xml
+++ b/.github/dependency-check-suppressions.xml
@@ -1,3 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE-2021-43138 is a prototype pollution vulnerability in the JavaScript async library
+        (caolan/async npm package), not the .NET System.Interactive.Async (Rx Ix.Async).
+        ]]></notes>
+        <filePath regex="true">.*System\.Interactive\.Async.*</filePath>
+        <cve>CVE-2021-43138</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Problem
DependencyCheck flags `System.Interactive.Async 3.1.1` with CVE-2021-43138 (HIGH 7.8).

CVE-2021-43138 is prototype pollution in the **JavaScript** `async` library ([caolan/async](https://github.com/caolan/async) on npm). `System.Interactive.Async` is a completely different **.NET** library from the Reactive Extensions team (Ix.Async for IAsyncEnumerable). DC matched on the word "async" across ecosystems.

The NVD description literally references `lib/internal/iterator.js`.

## Fix
Suppress CVE-2021-43138 for files matching `.*System\.Interactive\.Async.*`.